### PR TITLE
fix: Update position tracking logic for re-reproduced songs

### DIFF
--- a/scrobble_utils.py
+++ b/scrobble_utils.py
@@ -319,14 +319,14 @@ class PositionTracker:
                         'reason': 'new_song',
                         'should_scrobble': True
                     })
-                elif current_position < saved_song.get('max_array_position', float('inf')):
-                    # Re-reproduction - song moved up in the list
+                elif current_position < saved_song.get('array_position', float('inf')):
+                    # Re-reproduction - song moved up in the list (better position than previous session)
                     songs_to_scrobble.append({
                         'song': song,
                         'position': current_position,
                         'reason': 'reproduction',
                         'should_scrobble': True,
-                        'previous_max_position': saved_song.get('max_array_position')
+                        'previous_position': saved_song.get('array_position')
                     })
                 else:
                     # Song exists and hasn't moved up - just update position


### PR DESCRIPTION
Commit/PR Description

  Fix infinite scrobbling bug in standalone version (#23)

  The standalone version was incorrectly comparing current song positions against
  max_array_position instead of array_position, causing songs to be scrobbled 
  indefinitely when they hadn't actually improved their position.

  **Root Cause:**
  - Standalone version used `max_array_position` (worst position ever across all sessions)
  - Web version correctly uses `array_position` (position from most recent session)
  - Comparing positions across sessions with different song counts is unreliable

  **Example Bug Scenario:**
  - Song at position 40 today, position 28 last session, max position 127 historically
  - Old logic: 40 < 127 → scrobble (WRONG - song got worse: 28→40)
  - New logic: 40 < 28 → don't scrobble (CORRECT)

  **Changes:**
  - Updated `scrobble_utils.py:322` to compare against `array_position`
  - Matches the proven logic from ytmusic-scrobbler-web
  - Prevents hundreds of duplicate scrobbles for the same songs

  Fixes #23
