### PR TITLE
Feature: Support for 7 day scrobbles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YOUTUBE MUSIC LAST.FM SCROBBLER
 
-The YouTube Music Last.fm Scrobbler is a Python application that fetches your YouTube Music listening history from the last 24 hours and scrobbles it to Last.fm. This project offers two versions with different approaches and capabilities.
+The YouTube Music Last.fm Scrobbler is a Python application that fetches your YouTube Music listening history from the last 7 days and scrobbles it to Last.fm. This project offers two versions with different approaches and capabilities.
 
 ## 📋 Available Versions
 

--- a/date_detection.py
+++ b/date_detection.py
@@ -8,6 +8,7 @@ from typing import Dict, Set, List, Optional, NamedTuple
 class DateDetectionResult(NamedTuple):
     is_today: bool
     is_yesterday: bool
+    is_this_week: bool
     detected_language: Optional[str]
     original_value: str
 
@@ -149,6 +150,73 @@ YESTERDAY_TRANSLATIONS = {
     'երեկ': 'hy',           # Armenian
 }
 
+THIS_WEEK_TRANSLATIONS = {
+    # Latin script
+    'This week': 'en',         # English
+    'Esta semana': 'es',       # Spanish, Portuguese
+    'Questa settimana': 'it',  # Italian
+    'Cette semaine': 'fr',     # French
+    'Diese Woche': 'de',       # German
+    'Deze week': 'nl',         # Dutch
+    'Denna vecka': 'sv',       # Swedish
+    'Denne uken': 'no',        # Norwegian
+    'Tällä viikolla': 'fi',    # Finnish
+    'Šonedēļ': 'lv',           # Latvian
+    'Šią savaitę': 'lt',       # Lithuanian
+    'W tym tygodniu': 'pl',    # Polish
+    'Tento týden': 'cs',       # Czech
+    'Ta teden': 'sl',          # Slovenian
+    'Săptămâna aceasta': 'ro', # Romanian
+    'Sel nädalal': 'et',       # Estonian
+    'Bu hafta': 'tr',          # Turkish
+    'Αυτή την εβδομάδα': 'el', # Greek
+    'Тази седмица': 'bg',      # Bulgarian
+    'Ове недеље': 'sr',        # Serbian
+    'Ovaj tjedan': 'hr',       # Croatian
+    'Оваа недела': 'mk',       # Macedonian
+
+    # Cyrillic script
+    'На этой неделе': 'ru',    # Russian
+    'На цьому тижні': 'uk',    # Ukrainian
+    'На гэтым тыдні': 'be',    # Belarusian
+
+    # Arabic script
+    'هذا الأسبوع': 'ar',       # Arabic
+    'این هفته': 'fa',          # Persian/Farsi
+    'اس ہفتے': 'ur',           # Urdu
+
+    # CJK scripts
+    '本周': 'zh',               # Chinese Simplified
+    '今週': 'ja',               # Japanese
+    '이번 주': 'ko',            # Korean
+
+    # Indic scripts
+    'इस सप्ताह': 'hi',         # Hindi
+    'এই সপ্তাহ': 'bn',         # Bengali
+    'આ સપ્તાહ': 'gu',          # Gujarati
+    'இந்த வாரம்': 'ta',        # Tamil
+    'ఈ వారం': 'te',            # Telugu
+    'ಈ ವಾರ': 'kn',             # Kannada
+    'ഈ ആഴ്ച': 'ml',           # Malayalam
+    'ਇਹ ਹਫਤਾ': 'pa',          # Punjabi
+
+    # Southeast Asian
+    'สัปดาห์นี้': 'th',         # Thai
+    'Tuần này': 'vi',           # Vietnamese
+    'Minggu ini': 'id',         # Indonesian
+    'Linggong ito': 'tl',       # Filipino/Tagalog
+    'ယခုအပတ်': 'my',            # Burmese/Myanmar
+
+    # African languages
+    'Wiki hii': 'sw',           # Swahili
+    'Hierdie week': 'af',       # Afrikaans
+
+    # Other scripts
+    'השבוע': 'he',              # Hebrew
+    'ამ კვირაში': 'ka',          # Georgian
+    'այս շաբաթ': 'hy',           # Armenian
+}
+
 
 def detect_date_value(played_at: Optional[str]) -> DateDetectionResult:
     """
@@ -164,6 +232,7 @@ def detect_date_value(played_at: Optional[str]) -> DateDetectionResult:
         return DateDetectionResult(
             is_today=False,
             is_yesterday=False,
+            is_this_week=False,
             detected_language=None,
             original_value=played_at or ''
         )
@@ -175,6 +244,7 @@ def detect_date_value(played_at: Optional[str]) -> DateDetectionResult:
         return DateDetectionResult(
             is_today=True,
             is_yesterday=False,
+            is_this_week=False,
             detected_language=TODAY_TRANSLATIONS[trimmed],
             original_value=trimmed
         )
@@ -184,7 +254,18 @@ def detect_date_value(played_at: Optional[str]) -> DateDetectionResult:
         return DateDetectionResult(
             is_today=False,
             is_yesterday=True,
+            is_this_week=False,
             detected_language=YESTERDAY_TRANSLATIONS[trimmed],
+            original_value=trimmed
+        )
+    
+    # Check for this week
+    if trimmed in THIS_WEEK_TRANSLATIONS:
+        return DateDetectionResult(
+            is_today=False,
+            is_yesterday=False,
+            is_this_week=True,
+            detected_language=THIS_WEEK_TRANSLATIONS[trimmed],
             original_value=trimmed
         )
     
@@ -192,6 +273,7 @@ def detect_date_value(played_at: Optional[str]) -> DateDetectionResult:
     return DateDetectionResult(
         is_today=False,
         is_yesterday=False,
+        is_this_week=False,
         detected_language=None,
         original_value=trimmed
     )
@@ -206,6 +288,9 @@ def is_yesterday_song(played_at: Optional[str]) -> bool:
     """Check if a song was played yesterday"""
     return detect_date_value(played_at).is_yesterday
 
+def is_this_week_song(played_at: Optional[str]) -> bool:
+    """Check if a song was played this week"""
+    return detect_date_value(played_at).is_this_week
 
 def get_all_today_variants() -> List[str]:
     """Get all supported 'today' variants for debugging"""
@@ -215,6 +300,10 @@ def get_all_today_variants() -> List[str]:
 def get_all_yesterday_variants() -> List[str]:
     """Get all supported 'yesterday' variants for debugging"""
     return list(YESTERDAY_TRANSLATIONS.keys())
+
+def get_all_this_week_variants() -> List[str]:
+    """Get all supported 'this week' variants for debugging"""
+    return list(THIS_WEEK_TRANSLATIONS.keys())
 
 
 def get_unknown_date_values(songs: List[Dict[str, str]]) -> List[str]:
@@ -233,7 +322,7 @@ def get_unknown_date_values(songs: List[Dict[str, str]]) -> List[str]:
         played_at = song.get('playedAt')
         if played_at:
             result = detect_date_value(played_at)
-            if not result.is_today and not result.is_yesterday and played_at.strip():
+            if not result.is_today and not result.is_yesterday and not result.is_this_week and played_at.strip():
                 unknown_values.add(played_at.strip())
     
     return list(unknown_values)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ idna==3.7
 pysqlite3==0.5.1
 python-dotenv==1.0.0
 urllib3==2.6.0
+requests==2.32.5

--- a/scrobble_utils.py
+++ b/scrobble_utils.py
@@ -230,15 +230,18 @@ class SmartScrobbler:
                 for scrobble in scrobble_elements:
                     track_elem = scrobble.find('track')
                     artist_elem = scrobble.find('artist')
+                    album_elem = scrobble.find('album')
                     timestamp_elem = scrobble.find('timestamp')
                     ignored_message = scrobble.find('ignoredMessage')
 
                     track_corrected = track_elem.get('corrected', '0') if track_elem is not None else '0'
                     artist_corrected = artist_elem.get('corrected', '0') if artist_elem is not None else '0'
+                    album_corrected = album_elem.get('corrected', '0') if album_elem is not None else '0'
 
                     print(f"  [Scrobble Details]")
                     print(f"    Track: {track_elem.text if track_elem is not None else 'N/A'} (corrected: {track_corrected})")
                     print(f"    Artist: {artist_elem.text if artist_elem is not None else 'N/A'} (corrected: {artist_corrected})")
+                    print(f"    Album: {album_elem.text if album_elem is not None else 'N/A'} (corrected: {album_corrected})")
                     print(f"    Timestamp: {timestamp_elem.text if timestamp_elem is not None else 'N/A'}")
 
                     if ignored_message is not None and ignored_message.text:
@@ -284,10 +287,28 @@ class PositionTracker:
     
     def __init__(self):
         pass
+
+    @staticmethod 
+    def deduplicate_songs(songs) -> List[Dict]:
+        """Deduplicate songs accross today, yesterday, and this week.
+        This avoids rereproduction issues for overlaps.
+        Args:
+            songs: List of song dicts with 'title', 'artist', 'album' keys
+        Returns:
+            List of deduplicated song dicts
+        """
+        seen = set()
+        deduped = []
+        for song in songs:
+            key = (song['title'], song['artist'], song['album'])
+            if key not in seen:
+                deduped.append(song)
+                seen.add(key)
+        return deduped
     
     @staticmethod
     def detect_songs_to_scrobble(
-        today_songs: List[Dict[str, str]],
+        total_songs: List[Dict[str, str]],
         database_songs: List[Dict],
         is_first_time: bool = False,
         max_first_time_songs: int = 10
@@ -296,7 +317,7 @@ class PositionTracker:
         Determine which songs should be scrobbled based on position tracking
         
         Args:
-            today_songs: Songs from today's history (with position index)
+            total_songs: Songs from today's history (with position index)
             database_songs: Songs already in database with max_array_position
             is_first_time: Whether this is first time scrobbling for user
             max_first_time_songs: Maximum songs to scrobble for first-time users
@@ -308,7 +329,7 @@ class PositionTracker:
         
         if is_first_time:
             # First time: scrobble recent songs up to the limit
-            for i, song in enumerate(today_songs[:max_first_time_songs]):
+            for i, song in enumerate(total_songs[:max_first_time_songs]):
                 songs_to_scrobble.append({
                     'song': song,
                     'position': i + 1,
@@ -317,7 +338,7 @@ class PositionTracker:
                 })
             
             # Add remaining songs to database without scrobbling
-            for i, song in enumerate(today_songs[max_first_time_songs:], max_first_time_songs):
+            for i, song in enumerate(total_songs[max_first_time_songs:], max_first_time_songs):
                 songs_to_scrobble.append({
                     'song': song,
                     'position': i + 1,
@@ -326,7 +347,7 @@ class PositionTracker:
                 })
         else:
             # Regular processing: check for new songs and re-reproductions
-            for i, song in enumerate(today_songs):
+            for i, song in enumerate(total_songs):
                 current_position = i + 1
                 
                 # Find matching song in database

--- a/scrobble_utils.py
+++ b/scrobble_utils.py
@@ -289,7 +289,7 @@ class PositionTracker:
         pass
 
     @staticmethod 
-    def deduplicate_songs(songs) -> List[Dict]:
+    def deduplicate_songs(songs: List[Dict]) -> List[Dict]:
         """Deduplicate songs accross today, yesterday, and this week.
         This avoids rereproduction issues for overlaps.
         Args:

--- a/start_standalone.py
+++ b/start_standalone.py
@@ -230,17 +230,9 @@ class ImprovedProcess:
         print(f"Found {len(yesterday_songs)} songs played yesterday")
         print(f"Found {len(this_week_songs)} songs played this week")
 
-        if len(today_songs) == 0:
-            print("No songs played today. Nothing to scrobble.")
-            return True
-        
-        if len(yesterday_songs) == 0:
-            print("No songs played yesterday. Nothing to scrobble.")
-            return True
-
-        if len(this_week_songs) == 0:
-            print("No songs played this week. Nothing to scrobble.")
-            return True
+        if len(today_songs) == 0 and len(yesterday_songs) == 0 and len(this_week_songs) == 0:
+            print("No songs found from today, yesterday, or this week. Nothing to scrobble.")
+            return True        
 
         # Get existing songs from database
         cursor = self.conn.cursor()

--- a/start_standalone.py
+++ b/start_standalone.py
@@ -22,7 +22,7 @@ from typing import List, Dict, Optional
 
 # Import our new modules
 from ytmusic_fetcher import get_ytmusic_history_from_cookie
-from date_detection import is_today_song, get_unknown_date_values, get_detected_languages
+from date_detection import is_today_song, is_yesterday_song, is_this_week_song, get_unknown_date_values, get_detected_languages
 from scrobble_utils import SmartScrobbler, PositionTracker, FailureType
 
 load_dotenv()
@@ -207,6 +207,13 @@ class ImprovedProcess:
         # Filter songs played today using multilingual detection
         print("Filtering songs played today...")
         today_songs = [song for song in history if is_today_song(song.get('playedAt'))]
+
+        print("Filtering songs played yesterday...")
+        yesterday_songs = [song for song in history if is_yesterday_song(song.get('playedAt'))]
+
+        print("Filtering songs played this week...")
+        # Filter this week songs using multilingual detection 
+        this_week_songs = [song for song in history if is_this_week_song(song.get('playedAt'))]
         
         # Log unknown date values for future expansion
         unknown_values = get_unknown_date_values(history)
@@ -220,9 +227,19 @@ class ImprovedProcess:
             print(f"Detected languages in today's songs: {', '.join(detected_languages)}")
 
         print(f"Found {len(today_songs)} songs played today")
+        print(f"Found {len(yesterday_songs)} songs played yesterday")
+        print(f"Found {len(this_week_songs)} songs played this week")
 
         if len(today_songs) == 0:
             print("No songs played today. Nothing to scrobble.")
+            return True
+        
+        if len(yesterday_songs) == 0:
+            print("No songs played yesterday. Nothing to scrobble.")
+            return True
+
+        if len(this_week_songs) == 0:
+            print("No songs played this week. Nothing to scrobble.")
             return True
 
         # Get existing songs from database
@@ -259,12 +276,24 @@ class ImprovedProcess:
                         today_song['album'] == db_song['album']):
                         found = True
                         break
+                for yesterday_song in yesterday_songs:
+                    if (yesterday_song['title'] == db_song['title'] and 
+                        yesterday_song['artist'] == db_song['artist'] and 
+                        yesterday_song['album'] == db_song['album']):
+                        found = True
+                        break
+                for this_week_song in this_week_songs:
+                    if (this_week_song['title'] == db_song['title'] and 
+                        this_week_song['artist'] == db_song['artist'] and 
+                        this_week_song['album'] == db_song['album']):
+                        found = True
+                        break
                 
                 if not found:
                     songs_to_delete.append(db_song)
             
             if songs_to_delete:
-                print(f"Removing {len(songs_to_delete)} songs no longer in today's history")
+                print(f"Removing {len(songs_to_delete)} songs no longer in today's, yesterday's, or this week's history")
                 for song in songs_to_delete:
                     cursor.execute('''
                         DELETE FROM scrobbles 
@@ -272,10 +301,11 @@ class ImprovedProcess:
                     ''', (song['title'], song['artist'], song['album']))
                 self.conn.commit()
 
+        all_songs = self.position_tracker.deduplicate_songs(today_songs + yesterday_songs + this_week_songs)
         # Determine which songs to scrobble using smart position tracking
         max_first_time_songs = 10  # Can be made configurable
         songs_to_process = self.position_tracker.detect_songs_to_scrobble(
-            today_songs, database_songs, is_first_time, max_first_time_songs
+            all_songs, database_songs, is_first_time, max_first_time_songs
         )
 
         # Count how many will actually be scrobbled
@@ -355,7 +385,7 @@ class ImprovedProcess:
 
         cursor.close()
         
-        print(f"\\n✅ Scrobbling completed!")
+        print(f"✅ Scrobbling completed!")
         print(f"📊 Summary:")
         print(f"  - Total songs in today's history: {len(today_songs)}")
         print(f"  - Songs successfully scrobbled: {songs_scrobbled}")
@@ -377,16 +407,16 @@ def main():
         success = process.execute()
         
         if success:
-            print("\\n🎉 Process completed successfully!")
+            print("🎉 Process completed successfully!")
         else:
-            print("\\n❌ Process failed. Please check the errors above.")
+            print("❌ Process failed. Please check the errors above.")
             return 1
             
     except KeyboardInterrupt:
-        print("\\n⏹️  Process interrupted by user")
+        print("⏹️  Process interrupted by user")
         return 1
     except Exception as e:
-        print(f"\\n💥 Unexpected error: {e}")
+        print(f"💥 Unexpected error: {e}")
         return 1
     
     return 0


### PR DESCRIPTION
### Description
These changes implement support for 7 day scrobbles. This enables users to scan their music once every week, instead of every night. This change is additive and does not break daily scrobbling, so they should not introduce breaking changes or issues with current users, since tracking logic has not been modified. 

### Implementation
Besides checking `is_yesterday_song()` and `is_this_week_song()` I added a deduplication method to the `PostitionTracker` class, since there were issues with rereproduction overlaps when the same song was played today and this week. 

### Considerations
The `THIS_WEEK_TRANSLATIONS` dictionary introduced in `date_detection.py` is a **best guess** of what the actual translations are. There is no guarantee that youtube music follows these actual translations. I could not test all languages, therefore all translations were AI generated. I can confirm that the pt translation works. 

### Additional Changes
- Removed some unnecessary new line characters and added some extra logging for album information. 
- Added `requests==2.32.5` to `requirements.txt` since when I tested with python 3.9.25 this package was identified as missing. 
- Modified the readme to clarify 7-day support. 


If there are any implementation details you disagree with let me know and I'll do my best to change them. If you think this is not to be supported feel free to reject. 